### PR TITLE
"And" option for "Multi-words" search.

### DIFF
--- a/Fissoft.EntityFramework.Fts.Tests/UnitTest1.cs
+++ b/Fissoft.EntityFramework.Fts.Tests/UnitTest1.cs
@@ -40,5 +40,24 @@ namespace Fissoft.EntityFramework.Fts.Tests
                 
             }
         }
+
+        [TestMethod]
+        public void MyTestMethod_MultiWords()
+        {
+
+            using (var db = new MyDbContext())
+            {
+                db.Database.Log = (s =>
+                {
+                    Console.WriteLine(s);
+                });
+                var text = FullTextSearchModelUtil.Contains("a b",true);
+                var query = db.TestModel
+                    .Where(c => c.Name.Contains(text))
+
+                    .ToList(); // Should return results that contain BOTH words. For the second param = false, should return records with either of the words
+
+            }
+        }
     }
 }

--- a/Fissoft.EntityFramework.Fts/FullTextSearchModelUtil.cs
+++ b/Fissoft.EntityFramework.Fts/FullTextSearchModelUtil.cs
@@ -11,24 +11,24 @@ namespace Fissoft.EntityFramework.Fts
         public const string FullTextContainsAll = "-FTSFULLTEXTCONTAINSALL-";
         public const string FullTextFreeText = "-FTSFULLTEXTFREETEXT-";
         public const string FullTextFreeTextAll = "-FTSFULLTEXTFREETEXTALL-";
-        public static string Contains(string search)
+        public static string Contains(string search, bool matchAllWords = false)
         {
-            return string.Format("({0}{1})", FullTextContains, Convert(search));
+            return string.Format("({0}{1})", FullTextContains, Convert(search, matchAllWords));
         }
-        public static string ContainsAll(string search)
+        public static string ContainsAll(string search, bool matchAllWords = false)
         {
-            return string.Format("({0}{1})", FullTextContainsAll, Convert(search));
+            return string.Format("({0}{1})", FullTextContainsAll, Convert(search, matchAllWords));
         }
-        public static string FreeText(string search)
+        public static string FreeText(string search, bool matchAllWords = false)
         {
-            return string.Format("({0}{1})", FullTextFreeText, Convert(search));
+            return string.Format("({0}{1})", FullTextFreeText, Convert(search, matchAllWords));
         }
-        public static string FreeTextAll(string search)
+        public static string FreeTextAll(string search, bool matchAllWords = false)
         {
-            return string.Format("({0}{1})", FullTextFreeTextAll, Convert(search));
+            return string.Format("({0}{1})", FullTextFreeTextAll, Convert(search, matchAllWords));
         }
 
-        private static string Convert(string search)
+        private static string Convert(string search, bool matchAllWords = false)
         {
             if (string.IsNullOrWhiteSpace(search))
                 return search;
@@ -37,7 +37,10 @@ namespace Fissoft.EntityFramework.Fts
                 if (search.StartsWith("\"") && search.EndsWith("\""))
                     return search;
                 var words = search.Split(new[] { ' ', '　' });
-                return string.Join(" or ", words.Where(c => c != "or"));
+                if (matchAllWords)
+                    return string.Join(" and ", words.Where(c => c != "and"));
+                else
+                    return string.Join(" or ", words.Where(c => c != "or"));
             }
             else
             {


### PR DESCRIPTION
A new optional boolean parameter which when true, will return result-sets that satisfy the search for all the words. For instance, "a b" will fetch only results that contain both a and b.
When the optional parameter is not passed or is false, the existing behavior holds good.